### PR TITLE
Add cl-lib to Package-Requires

### DIFF
--- a/pcomplete-extension.el
+++ b/pcomplete-extension.el
@@ -5,7 +5,7 @@
 ;; X-URL: https://github.com/thierryvolpiatto/pcomplete-extension
 
 ;; Compatibility: GNU Emacs 24.1+
-;; Package-Requires: ((emacs "24"))
+;; Package-Requires: ((emacs "24") (cl-lib "0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This is necessary for Emacs 24.2 or lower.
